### PR TITLE
Added scgi_params & uwsgi_params to supported files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Simply [download](https://github.com/brandonwamboldt/sublime-nginx/archive/maste
 Usage
 -----
 
-This package will recognize `*.conf`, `*.conf.erb`, `nginx.conf`, `mime.types`, and `fastcgi_params` by default. 
+This package will recognize `*.conf`, `*.conf.erb`, `nginx.conf`, `mime.types`, `fastcgi_params`, `scgi_params`, and `uwsgi_params` by default.
 
 Screenshots
 -----------

--- a/Syntaxes/nginx.sublime-syntax
+++ b/Syntaxes/nginx.sublime-syntax
@@ -8,6 +8,8 @@ file_extensions:
   - nginx.conf
   - mime.types
   - fastcgi_params
+  - scgi_params
+  - uwsgi_params
 scope: source.nginx
 contexts:
   main:

--- a/Syntaxes/nginx.tmLanguage
+++ b/Syntaxes/nginx.tmLanguage
@@ -9,6 +9,8 @@
     <string>nginx.conf</string>
     <string>mime.types</string>
     <string>fastcgi_params</string>
+    <string>scgi_params</string>
+    <string>uwsgi_params</string>
   </array>
   <key>foldingStartMarker</key>
   <string>\{\s*$</string>


### PR DESCRIPTION
Hi @brandonwamboldt,
on fresh nginx installation (version 1.8.0 on OS X 10.9) I found two more files `scgi_params` & `uwsgi_params` that are not supported by syntax highlighting by default.
What do you think about adding them?

Best,
@szemek