### PR TITLE
Fix: `map` as a block, instead of a directive

### DIFF
--- a/Syntaxes/nginx.sublime-syntax
+++ b/Syntaxes/nginx.sublime-syntax
@@ -243,7 +243,19 @@ contexts:
         - match: ;
           pop: true
         - include: values
-    - match: \b(map|map_hash_max_size|map_hash_bucket_size)\b
+    - match: '\b(map) +(\$[A-Za-z0-9\_]+) +(\$[A-Za-z0-9\_]+) *\{'
+      captures:
+        1: storage.type.context.nginx
+        2: variable.other.nginx
+        3: variable.other.nginx
+      push:
+        - meta_scope: meta.context.map.nginx
+        - match: '\}'
+          pop: true
+        - include: values
+        - match: ;
+          scope: punctuation.definition.map.nginx
+    - match: \b(map_hash_max_size|map_hash_bucket_size)\b
       captures:
         1: keyword.directive.module.http.map.nginx
       push:

--- a/Syntaxes/nginx.tmLanguage
+++ b/Syntaxes/nginx.tmLanguage
@@ -701,8 +701,47 @@
       <string>punctuation.definition.variable</string>
     </dict>
     <dict>
+      <key>name</key>
+      <string>meta.context.map.nginx</string>
       <key>begin</key>
-      <string>\b(map|map_hash_max_size|map_hash_bucket_size)\b</string>
+      <string>\b(map) +(\$[A-Za-z0-9\_]+) +(\$[A-Za-z0-9\_]+) *\{</string>
+      <key>end</key>
+      <string>\}</string>
+      <key>beginCaptures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>storage.type.context.nginx</string>
+        </dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>variable.other.nginx</string>
+        </dict>
+        <key>3</key>
+        <dict>
+          <key>name</key>
+          <string>variable.other.nginx</string>
+        </dict>
+      </dict>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>#values</string>
+        </dict>
+        <dict>
+          <key>match</key>
+          <string>;</string>
+          <key>name</key>
+          <string>punctuation.definition.map.nginx</string>
+        </dict>
+      </array>
+    </dict>
+    <dict>
+      <key>begin</key>
+      <string>\b(map_hash_max_size|map_hash_bucket_size)\b</string>
       <key>captures</key>
       <dict>
         <key>1</key>


### PR DESCRIPTION
Hello @brandonwamboldt

Thank you for making this nginx grammar!

I have had a go at parsing [`map`](http://nginx.org/en/docs/http/ngx_http_map_module.html#map) as a block instead of a directive. This is my first time working with language grammars so please let me know if I've got something wrong.

I created two new scopes:
- `meta.context.map.nginx`
- `punctuation.definition.map.nginx` (because I wasn't sure if `punctuation.definition.variable` should apply here)

Before: ![before](https://cloud.githubusercontent.com/assets/11390066/12979967/2251cece-d0d2-11e5-9a79-ab5868baa1b6.PNG) After: ![after](https://cloud.githubusercontent.com/assets/11390066/12979973/26ae53fc-d0d2-11e5-8765-6c02aaac5e68.PNG)

Please let me know if I should change anything.

Thanks again