### PR TITLE
Fix: Match the 'case-insensitive' regexp asterisk

### DIFF
--- a/Syntaxes/nginx.sublime-syntax
+++ b/Syntaxes/nginx.sublime-syntax
@@ -393,7 +393,7 @@ contexts:
       scope: constant.language.nginx
     - match: '[\t ](kqueue|rtsig|epoll|\/dev\/poll|select|poll|eventport|max|all|default_server|default|main|crit|error|debug|warn|notice|last)(?=[\t ;])'
       scope: constant.language.nginx
-    - match: \\.*\ |\~|\~\*|\!\~|\!\~\*
+    - match: \\.*\ |\~\*|\~|\!\~\*|\!\~
       scope: string.regexp.nginx
     - match: \^.*?\$
       scope: string.regexp.nginx

--- a/Syntaxes/nginx.tmLanguage
+++ b/Syntaxes/nginx.tmLanguage
@@ -1162,7 +1162,7 @@
         </dict>
         <dict>
           <key>match</key>
-          <string>\\.*\ |\~|\~\*|\!\~|\!\~\*</string>
+          <string>\\.*\ |\~\*|\~|\!\~\*|\!\~</string>
           <key>name</key>
           <string>string.regexp.nginx</string>
         </dict>


### PR DESCRIPTION
Match:
- `\~\*` before `\~`
- `\!\~\*` before `\!\~`

Otherwise the asterisk is not matched.