### PR TITLE
Add lua block support for st3

### DIFF
--- a/Syntaxes/nginx.sublime-syntax
+++ b/Syntaxes/nginx.sublime-syntax
@@ -368,6 +368,11 @@ contexts:
         - match: ;
           pop: true
         - include: values
+    - match: '\b.*_by_lua_block\s+\{'
+      push: Packages/Lua/Lua.sublime-syntax
+      with_prototype:
+        - match: '^\s*\}'
+          pop: true
     - match: '\b([a-zA-Z0-9\_]+)\s+'
       captures:
         1: keyword.directive.module.unsupported.nginx


### PR DESCRIPTION
I add a small piece of code to support `*_by_lua_block` in st3.

### Not supported in st2
Forgive me that I don't want to waste time modifying tmLanguage version to implement the same feature because I am not familiar with it and st2 is not recommended.

Further more, I doubt whether tmLanguage supports embedded  language because sublime_syntax is superset of tmLanguage.

### LImit to lua code
Only lua block is supported because inline lua code is discouraged.

Beside, Lua code block is ended by an alone `}` in a new line so lua table's `}` must not be placed that way. I can not mange to solve this and maybe it can not solved because inline javascript in html has the same problem:

    <!DOCTYPE html>
    <html lang="en">
    <head>
        <meta charset="UTF-8">
        <title>Document</title>
        <script>
            var str = '</script>';
            // </script>
        </script>
    </head>
    <body>
        <h1>hello world</h1>
    </body>
    </html>

`</script>` in string or comment will break the javascript code and return to html.

If there is a way to fix this, don't forget to notify me.

Thank you.