### PR TITLE
fix: correct comment highlight inside `map` block directive

### DIFF
--- a/Syntaxes/nginx.sublime-syntax
+++ b/Syntaxes/nginx.sublime-syntax
@@ -255,6 +255,8 @@ contexts:
         - include: values
         - match: ;
           scope: punctuation.definition.map.nginx
+        - match: \#.*
+          scope: comment.line.number-sign
     - match: \b(map_hash_max_size|map_hash_bucket_size)\b
       captures:
         1: keyword.directive.module.http.map.nginx

--- a/Syntaxes/nginx.tmLanguage
+++ b/Syntaxes/nginx.tmLanguage
@@ -738,6 +738,12 @@
           <key>name</key>
           <string>punctuation.definition.map.nginx</string>
         </dict>
+        <dict>
+          <key>match</key>
+          <string>\#.*</string>
+          <key>name</key>
+          <string>comment.line.number-sign</string>
+        </dict>
       </array>
     </dict>
     <dict>


### PR DESCRIPTION
This patch fixes comment highlight inside `map` block directive.

Before:
![before](https://i.imgur.com/kRj7wNJ.png)

After:
![after](https://i.imgur.com/TTGBiwv.png)

closes: #18 