### PR TITLE
Fix Lua block syntax highlighting

### DIFF
--- a/Syntaxes/nginx.sublime-syntax
+++ b/Syntaxes/nginx.sublime-syntax
@@ -374,7 +374,7 @@ contexts:
       push: Packages/Lua/Lua.sublime-syntax
       with_prototype:
         - match: '^\s*\}'
-          pop: true
+          pop: 3
     - match: '\b([a-zA-Z0-9\_]+)\s+'
       captures:
         1: keyword.directive.module.unsupported.nginx


### PR DESCRIPTION
Currently, opening a Lua block (e.g. with `content_by_lua_block`) causes the Lua syntax highlighter to bleed into the remainder of the file. Changing `match` from `true` to `3` seems to solve this problem, though I don't know enough about Sublime Text syntax definitions to understand why, or whether this is the correct way to fix the problem.

Support for popping more than one context off the stack like this is described in the `pop` section here: https://www.sublimetext.com/docs/syntax.html#match_patterns

Note: I'm using Sublime Text 4 (Build 4113), but I remember this problem being present in Sublime Text 3 as well. Also thanks for this package — it makes editing nginx files much easier.