### PR TITLE
Register nginx symbols (Ctrl+R) + Outline

### DIFF
--- a/Preferences/Symbols.tmPreferences
+++ b/Preferences/Symbols.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>name</key>
+    <string>Symbol List</string>
+    <key>scope</key>
+    <string>entity.name.context.location.nginx,
+    meta.context.location.nginx string.regexp.nginx,
+    meta.context.server.nginx storage.type.context.nginx,
+    meta.context.http.nginx storage.type.context.nginx,
+    meta.context.events.nginx storage.type.context.nginx</string>
+    <key>settings</key>
+    <dict>
+      <key>showInSymbolList</key>
+      <integer>1</integer>
+    </dict>
+  </dict>
+</plist>


### PR DESCRIPTION
Registers symbols for display in SublimeText when navigating symbols.

Api documentation at:
https://sublime-text-unofficial-documentation.readthedocs.io/en/latest/reference/symbols.html

Symbols Screenshot:
![Symbols](https://github.com/brandonwamboldt/sublime-nginx/assets/10236768/78abde12-9093-4914-a5bb-bdc6097cd83b)

Outline Screenshot:
![Outline](https://github.com/brandonwamboldt/sublime-nginx/assets/10236768/adc48a4b-ecf1-4599-a489-c9a197d431cf)
